### PR TITLE
Add xsi:type to value (CDA R2)

### DIFF
--- a/Result_panel_with_pending_component.xml
+++ b/Result_panel_with_pending_component.xml
@@ -51,7 +51,7 @@
                         <!-- The more common scenario is the result is not present -->
                         <!-- The task force created this example becasue it came up during certification testing-->
                         <!-- We do not believe this is a common scenario -->
-                        <value nullFlavor="NA"/>
+                        <value xsi:type="PQ" nullFlavor="NA"/>
                         </observation>
                 </component>
             </organizer>


### PR DESCRIPTION
Update based on inclusion of this example in C-CDA R2.0 IG package. Needs xsi:type to validate in base CDA schema
